### PR TITLE
enable everything on stable toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,6 @@ jobs:
     - name: Set Rustup profile to minimal
       run: rustup set profile minimal
 
-    - name: Switch to Rust nightly
-      run: rustup default nightly
-
     - name: Install Target Support
       run: |
         rustup target add ${{ matrix.target }}
@@ -70,9 +67,7 @@ jobs:
     timeout-minutes: 2
     steps:
     - uses: actions/checkout@v1
-    - run: rustup toolchain install nightly --profile minimal --component rustfmt
-    - run: rustup default nightly
-    - run: cargo +nightly fmt -- --check
+    - run: cargo fmt -- --check
 
   clippy:
     name: Clippy
@@ -91,7 +86,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - run: rustup toolchain install nightly --profile minimal --component clippy
-    - run: rustup default nightly
     - run: rustup target add ${{ matrix.target }}
     - run: cargo clippy --target=${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ exclude = [
 ]
 
 [features]
-default = ["nightly"]
-nightly = ["tock-registers"]
+default = ["tock-registers"]
 
 [dependencies]
 tock-registers = { version = "0.8.x", default-features = false, optional = true } # Use it as interface-only library.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,5 @@ exclude = [
         "Makefile"
 ]
 
-[features]
-default = ["tock-registers"]
-
 [dependencies]
-tock-registers = { version = "0.8.x", default-features = false, optional = true } # Use it as interface-only library.
+tock-registers = { version = "0.8.x", default-features = false } # Use it as interface-only library.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,6 @@
 
 Low level access to processors using the AArch64 execution state.
 
-## Minimum Supported Rust Version
-
-Requires a recent nightly of Rust if the (default) `nightly` feature is enabled. Without this the
-register access module is not available.
-
 ## Usage
 
 Please note that for using this crate's [register definitions](src/registers) (as provided by

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
-channel = "nightly"
 targets = ["aarch64-unknown-none-softfloat"]

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -9,8 +9,6 @@
 //! Wrappers around ARMv8-A instructions.
 
 pub mod barrier;
-
-#[cfg(feature = "nightly")]
 pub mod random;
 
 /// The classic no-op

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,6 @@
 
 //! Low level access to processors using the AArch64 execution state.
 //!
-//! ## Minimum Supported Rust Version
-//!
-//! Requires a recent nightly of Rust if the (default) `nightly` feature is enabled. Without this
-//! the register access module is not available.
-//!
 //! ## Usage
 //!
 //! Please note that for using this crate's [register definitions](src/registers) (as provided by
@@ -46,7 +41,6 @@
 //!
 //! // Some parts omitted for brevity.
 //!
-//! # #[cfg(feature = "nightly")]
 //! unsafe fn prepare_el2_to_el1_transition(
 //!     virt_boot_core_stack_end_exclusive_addr: u64,
 //!     virt_kernel_init_addr: u64,
@@ -77,10 +71,8 @@
 //! ARMv8, for ARMv8-A architecture
 //! profile](https://static.docs.arm.com/ddi0487/ca/DDI0487C_a_armv8_arm.pdf?_ga=2.266626254.1122218691.1534883460-1326731866.1530967873).
 
-#![cfg_attr(feature = "nightly", feature(core_intrinsics))]
-#![cfg_attr(feature = "nightly", feature(custom_inner_attributes))]
 #![no_std]
 
 pub mod asm;
-#[cfg(feature = "nightly")]
+#[cfg(feature = "tock-registers")]
 pub mod registers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,5 +74,4 @@
 #![no_std]
 
 pub mod asm;
-#[cfg(feature = "tock-registers")]
 pub mod registers;

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,7 +1,6 @@
 //! Processor core registers
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #[macro_use]
 mod macros;
@@ -22,10 +21,10 @@ mod cntv_cval_el0;
 mod cntv_tval_el0;
 mod cntvct_el0;
 mod cntvoff_el2;
-mod csselr_el1;
 mod cpacr_el1;
-mod dacr32_el2;
+mod csselr_el1;
 mod currentel;
+mod dacr32_el2;
 mod daif;
 mod elr_el1;
 mod elr_el2;
@@ -36,8 +35,8 @@ mod far_el1;
 mod far_el2;
 mod fp;
 mod hcr_el2;
-mod id_aa64mmfr0_el1;
 mod id_aa64isar0_el1;
+mod id_aa64mmfr0_el1;
 mod id_aa64mmfr1_el1;
 mod id_aa64mmfr2_el1;
 mod lr;
@@ -86,10 +85,10 @@ pub use cntv_cval_el0::CNTV_CVAL_EL0;
 pub use cntv_tval_el0::CNTV_TVAL_EL0;
 pub use cntvct_el0::CNTVCT_EL0;
 pub use cntvoff_el2::CNTVOFF_EL2;
-pub use csselr_el1::CSSELR_EL1;
 pub use cpacr_el1::CPACR_EL1;
-pub use dacr32_el2::DACR32_EL2;
+pub use csselr_el1::CSSELR_EL1;
 pub use currentel::CurrentEL;
+pub use dacr32_el2::DACR32_EL2;
 pub use daif::DAIF;
 pub use elr_el1::ELR_EL1;
 pub use elr_el2::ELR_EL2;
@@ -100,8 +99,8 @@ pub use far_el1::FAR_EL1;
 pub use far_el2::FAR_EL2;
 pub use fp::FP;
 pub use hcr_el2::HCR_EL2;
-pub use id_aa64mmfr0_el1::ID_AA64MMFR0_EL1;
 pub use id_aa64isar0_el1::ID_AA64ISAR0_EL1;
+pub use id_aa64mmfr0_el1::ID_AA64MMFR0_EL1;
 pub use id_aa64mmfr1_el1::ID_AA64MMFR1_EL1;
 pub use id_aa64mmfr2_el1::ID_AA64MMFR2_EL1;
 pub use lr::LR;

--- a/src/registers/vtcr_el2.rs
+++ b/src/registers/vtcr_el2.rs
@@ -121,4 +121,3 @@ impl Writeable for Reg {
 }
 
 pub const VTCR_EL2: Reg = Reg {};
-


### PR DESCRIPTION
I'd like to be able to use the registers with stable Rust, and as far as I can tell, there was nothing really in the library that actually required nightly.

Is it reasonable to just remove the nightly requirement like this?