### PR TITLE
Add VBAR_EL3 register and SCR_EL3 fields

### DIFF
--- a/src/registers.rs
+++ b/src/registers.rs
@@ -66,6 +66,7 @@ mod ttbr0_el2;
 mod ttbr1_el1;
 mod vbar_el1;
 mod vbar_el2;
+mod vbar_el3;
 mod vtcr_el2;
 mod vttbr_el2;
 
@@ -130,5 +131,6 @@ pub use ttbr0_el2::TTBR0_EL2;
 pub use ttbr1_el1::TTBR1_EL1;
 pub use vbar_el1::VBAR_EL1;
 pub use vbar_el2::VBAR_EL2;
+pub use vbar_el3::VBAR_EL3;
 pub use vtcr_el2::VTCR_EL2;
 pub use vttbr_el2::VTTBR_EL2;

--- a/src/registers/scr_el3.rs
+++ b/src/registers/scr_el3.rs
@@ -62,6 +62,38 @@ register_bitfields! {u64,
             SmcDisabled = 1
         ],
 
+        /// External Abort and SError interrupt routing.
+        /// 0 When executing at Exception levels below EL3, External aborts and SError interrupts are not taken to EL3.
+        ///     In addition, when executing at EL3:
+        ///       SError interrupts are not taken.
+        ///       External aborts are taken to EL3.
+        ///
+        /// 1 When executing at any Exception level, External aborts and SError interrupts are taken to EL3.
+        EA  OFFSET(3) NUMBITS(1) [
+            NotTaken = 0,
+            Taken = 1
+        ],
+
+        /// Physical FIQ Routing.
+        /// 0 When executing at Exception levels below EL3, physical FIQ interrupts are not taken
+        ///   to EL3. When executing at EL3, physical FIQ interrupts are not taken.
+        ///
+        /// 1 When executing at any Exception level, physical FIQ interrupts are taken to EL3.
+        FIQ OFFSET(2) NUMBITS(1) [
+            NotTaken = 0,
+            Taken = 1
+        ],
+
+        /// Physical IRQ Routing.
+        /// 0 When executing at Exception levels below EL3, physical IRQ interrupts are not taken
+        ///   to EL3. When executing at EL3, physical IRQ interrupts are not taken.
+        ///
+        /// 1 When executing at any Exception level, physical IRQ interrupts are taken to EL3.
+        IRQ OFFSET(1) NUMBITS(1) [
+            NotTaken = 0,
+            Taken = 1
+        ],
+
         /// Non-secure bit.
         /// 0 Indicates that EL0 and EL1 are in Secure state.
         ///
@@ -69,7 +101,7 @@ register_bitfields! {u64,
         ///   accesses from those Exception levels cannot access Secure memory.
         ///
         /// When SCR_EL3.{EEL2, NS} == {1, 0}, then EL2 is using AArch64 and in Secure state.
-        NS   OFFSET(0) NUMBITS(1) [
+        NS  OFFSET(0) NUMBITS(1) [
             Secure = 0,
             NonSecure = 1
         ]

--- a/src/registers/vbar_el3.rs
+++ b/src/registers/vbar_el3.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (c) 2018-2022 by the author(s)
+//
+// Author(s):
+//   - Andre Richter <andre.o.richter@gmail.com>
+//   - Javier Alvarez <javier.alvarez@allthingsembedded.net>
+
+//! Vector Base Address Register - EL3
+//!
+//! Holds the vector base address for any exception that is taken to EL3.
+
+use tock_registers::interfaces::{Readable, Writeable};
+
+pub struct Reg;
+
+impl Readable for Reg {
+    type T = u64;
+    type R = ();
+
+    sys_coproc_read_raw!(u64, "VBAR_EL3", "x");
+}
+
+impl Writeable for Reg {
+    type T = u64;
+    type R = ();
+
+    sys_coproc_write_raw!(u64, "VBAR_EL3", "x");
+}
+
+pub const VBAR_EL3: Reg = Reg {};


### PR DESCRIPTION
- Adds the VBAR_EL3 register. This is pretty much copied/pasted from VBAR_EL1/2.
- Adds missing fields from the SCR_EL3 register.