### PR TITLE
Set CPACR_EL1 register for `Readable` and `Writeable`

### DIFF
--- a/src/registers/cpacr_el1.rs
+++ b/src/registers/cpacr_el1.rs
@@ -113,14 +113,14 @@ pub struct Reg;
 
 impl Readable for Reg {
     type T = u64;
-    type R = ();
+    type R = CPACR_EL1::Register;
 
     sys_coproc_read_raw!(u64, "CPACR_EL1", "x");
 }
 
 impl Writeable for Reg {
     type T = u64;
-    type R = ();
+    type R = CPACR_EL1::Register;
 
     sys_coproc_write_raw!(u64, "CPACR_EL1", "x");
 }


### PR DESCRIPTION
This change is required to access the `CPACR_EL1` register fields.