### PR TITLE
Set ESR_ELX writable

### DIFF
--- a/src/registers/esr_el1.rs
+++ b/src/registers/esr_el1.rs
@@ -10,7 +10,10 @@
 //!
 //! Holds syndrome information for an exception taken to EL1.
 
-use tock_registers::{interfaces::Readable, register_bitfields};
+use tock_registers::{
+    interfaces::{Readable, Writeable},
+    register_bitfields,
+};
 
 register_bitfields! {u64,
     pub ESR_EL1 [
@@ -77,6 +80,13 @@ impl Readable for Reg {
     type R = ESR_EL1::Register;
 
     sys_coproc_read_raw!(u64, "ESR_EL1", "x");
+}
+
+impl Writeable for Reg {
+    type T = u64;
+    type R = ();
+
+    sys_coproc_write_raw!(u64, "ESR_EL1", "x");
 }
 
 pub const ESR_EL1: Reg = Reg {};

--- a/src/registers/esr_el2.rs
+++ b/src/registers/esr_el2.rs
@@ -11,7 +11,10 @@
 //!
 //! Holds syndrome information for an exception taken to EL2.
 
-use tock_registers::{interfaces::Readable, register_bitfields};
+use tock_registers::{
+    interfaces::{Readable, Writeable},
+    register_bitfields,
+};
 
 register_bitfields! {u64,
     pub ESR_EL2 [
@@ -89,6 +92,13 @@ impl Readable for Reg {
     type R = ESR_EL2::Register;
 
     sys_coproc_read_raw!(u64, "ESR_EL2", "x");
+}
+
+impl Writeable for Reg {
+    type T = u64;
+    type R = ();
+
+    sys_coproc_write_raw!(u64, "ESR_EL2", "x");
 }
 
 pub const ESR_EL2: Reg = Reg {};


### PR DESCRIPTION
According to the Arm Architecture Reference Manual (DDI 0487H.a), sections C5.2.5 and C5.2.6, `ESR_EL1` and `ESR_EL2` can be written to. Whether the write succeeds depends on which exception level we are running in, but this is not a concern for the aarch64-cpu crate.

Implement the Writeable interface for `ESR_EL1` and `ESR_EL2`.