### PR TITLE
Use the correct number of bits for VTTBR_EL2.BADDR

### DIFF
--- a/src/registers/vttbr_el2.rs
+++ b/src/registers/vttbr_el2.rs
@@ -19,7 +19,7 @@ register_bitfields! {u64,
         VMID  OFFSET(48) NUMBITS(16) [],
 
         /// Translation table base address
-        BADDR OFFSET(1) NUMBITS(48) [],
+        BADDR OFFSET(1) NUMBITS(47) [],
 
         /// Common not Private
         CnP   OFFSET(0) NUMBITS(1) []


### PR DESCRIPTION
According to section D19.2.166 "VTTBR_EL2, Virtualization Translation Table Base Register" of ARM ARM DDI 0487J.a, BADDR field of VTTBR_EL2 is 47 bits, not 48.