### PR TITLE
Reexport `tock-registers` interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,25 +17,8 @@ It might compile with older versions but that may change in any new patch releas
 ## Usage
 
 Please note that for using this crate's [register definitions](src/registers) (as provided by
-`aarch64_cpu::registers::*`), you need to also include
-[`tock-registers`](https://crates.io/crates/tock-registers) in your project. This is because the
-`interface` traits provided by `tock-registers` are implemented by this crate. You should include
-the same version of `tock-registers` as is being used by this crate to ensure sane
-interoperatbility.
-
-For example, in the following snippet, `X.Y.Z` should be the same version of `tock-registers` that
-is mentioned in `aarch64-cpu`'s [`Cargo.toml`](Cargo.toml#L23).
-
-```toml
-[package]
-name = "Your embedded project"
-
-# Some parts omitted for brevity.
-
-[dependencies]
-tock-registers = "X.Y.Z"
-aarch64-cpu = "A.B.C"       # <-- Includes tock-registers itself.
-```
+`aarch64_cpu::registers::*`), you need to also import
+`aarch64_cpu::registers::{Readable, Writeable}`.
 
 ### Example
 
@@ -44,7 +27,6 @@ below is a snippet of `rust-raspberrypi-OS-tutorials`'s early boot code.
 
 ```rust
 use aarch64_cpu::{asm, registers::*};
-use tock_registers::interfaces::Writeable; // <-- Trait needed to use `write()` and `set()`.
 
 // Some parts omitted for brevity.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,25 +10,8 @@
 //! ## Usage
 //!
 //! Please note that for using this crate's [register definitions](src/registers) (as provided by
-//! `aarch64_cpu::registers::*`), you need to also include
-//! [`tock-registers`](https://crates.io/crates/tock-registers) in your project. This is because the
-//! `interface` traits provided by `tock-registers` are implemented by this crate. You should
-//! include the same version of `tock-registers` as is being used by this crate to ensure sane
-//! interoperatbility.
-//!
-//! For example, in the following snippet, `X.Y.Z` should be the same version of `tock-registers`
-//! that is mentioned in `aarch64-cpu`'s [`Cargo.toml`](Cargo.toml#L27).
-//!
-//! ```toml
-//! [package]
-//! name = "Your embedded project"
-//!
-//! # Some parts omitted for brevity.
-//!
-//! [dependencies]
-//! tock-registers = "X.Y.Z"
-//! aarch64-cpu = "A.B.C"       # <-- Includes tock-registers itself.
-//! ```
+//! `aarch64_cpu::registers::*`), you need to also import [`Readable`](registers::Readable) and
+//! [`Writeable`](registers::Writeable).
 //!
 //! ### Example
 //!
@@ -37,7 +20,6 @@
 //!
 //! ```rust
 //! use aarch64_cpu::{asm, registers::*};
-//! use tock_registers::interfaces::Writeable; // <-- Trait needed to use `write()` and `set()`.
 //!
 //! // Some parts omitted for brevity.
 //!

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -178,3 +178,6 @@ pub use vbar_el2::VBAR_EL2;
 pub use vbar_el3::VBAR_EL3;
 pub use vtcr_el2::VTCR_EL2;
 pub use vttbr_el2::VTTBR_EL2;
+
+#[doc(inline)]
+pub use tock_registers::interfaces::{Readable, Writeable};


### PR DESCRIPTION
Closes #19.