### PR TITLE
registers: Reexport `ReadWriteable`

### DIFF
--- a/src/registers.rs
+++ b/src/registers.rs
@@ -180,4 +180,4 @@ pub use vtcr_el2::VTCR_EL2;
 pub use vttbr_el2::VTTBR_EL2;
 
 #[doc(inline)]
-pub use tock_registers::interfaces::{Readable, Writeable};
+pub use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};


### PR DESCRIPTION
The tock-registers::interfaces::ReadWriteable trait allows us to use the `modify()` function. It is useful for setting flags in a clean way.