### PR TITLE
Add hfgrtr_el2 support

### DIFF
--- a/src/registers/hfgrtr_el2.rs
+++ b/src/registers/hfgrtr_el2.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (c) 2018-2023 by the author(s)
+//
+// Author(s):
+//   - Valentin B. <valentin.be@protonmail.com>
+
+//! Hypervisor Fault Group Register - EL2
+//!
+//! Provides implementation-defined configuration and control options for execution
+//! at EL2.
+
+use tock_registers::interfaces::{Readable, Writeable};
+
+pub struct Reg;
+
+impl Readable for Reg {
+    type T = u64;
+    type R = ();
+
+    sys_coproc_read_raw!(u64, "HFGRTR_EL2", "x");
+}
+
+impl Writeable for Reg {
+    type T = u64;
+    type R = ();
+
+    sys_coproc_write_raw!(u64, "HFGRTR_EL2", "x");
+}
+
+pub const HFGRTR_EL2: Reg = Reg;


### PR DESCRIPTION
Hypervisor Fault Group Register - EL2
Provides implementation-defined configuration and control options for execution