### PR TITLE
Add hypervisor register support

### DIFF
--- a/src/registers.rs
+++ b/src/registers.rs
@@ -133,7 +133,7 @@ mod vbar_el3;
 mod vtcr_el2;
 mod vttbr_el2;
 mod hfgrtr_el2;
-
+mod hfgitr_el2;
 pub use actlr_el1::ACTLR_EL1;
 pub use actlr_el2::ACTLR_EL2;
 pub use actlr_el3::ACTLR_EL3;
@@ -262,6 +262,6 @@ pub use vbar_el3::VBAR_EL3;
 pub use vtcr_el2::VTCR_EL2;
 pub use vttbr_el2::VTTBR_EL2;
 pub use hfgrtr_el2::HFGRTR_EL2;
-
+pub use hfgitr_el2::HFGITR_EL2;
 #[doc(inline)]
 pub use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -132,6 +132,7 @@ mod vbar_el2;
 mod vbar_el3;
 mod vtcr_el2;
 mod vttbr_el2;
+mod hfgrtr_el2;
 
 pub use actlr_el1::ACTLR_EL1;
 pub use actlr_el2::ACTLR_EL2;
@@ -260,6 +261,7 @@ pub use vbar_el2::VBAR_EL2;
 pub use vbar_el3::VBAR_EL3;
 pub use vtcr_el2::VTCR_EL2;
 pub use vttbr_el2::VTTBR_EL2;
+pub use hfgrtr_el2::HFGRTR_EL2;
 
 #[doc(inline)]
 pub use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};

--- a/src/registers/hfgitr_el2.rs
+++ b/src/registers/hfgitr_el2.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (c) 2018-2023 by the author(s)
+//
+// Author(s):
+//   - Valentin B. <valentin.be@protonmail.com>
+
+//! Hypervisor Fault Group Information Register - EL2
+//!
+//! Provides information about the fault group.
+
+use tock_registers::interfaces::{Readable, Writeable};
+
+pub struct Reg;
+
+impl Readable for Reg {
+    type T = u64;
+    type R = ();
+
+    sys_coproc_read_raw!(u64, "HFGITR_EL2", "x");
+}
+
+impl Writeable for Reg {
+    type T = u64;
+    type R = ();
+
+    sys_coproc_write_raw!(u64, "HFGITR_EL2", "x");
+}
+
+pub const HFGITR_EL2: Reg = Reg;

--- a/src/registers/hfgrtr_el2.rs
+++ b/src/registers/hfgrtr_el2.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (c) 2018-2023 by the author(s)
+//
+// Author(s):
+//   - Valentin B. <valentin.be@protonmail.com>
+
+//! Hypervisor Fault Group Register - EL2
+//!
+//! Provides implementation-defined configuration and control options for execution
+//! at EL2.
+
+use tock_registers::interfaces::{Readable, Writeable};
+
+pub struct Reg;
+
+impl Readable for Reg {
+    type T = u64;
+    type R = ();
+
+    sys_coproc_read_raw!(u64, "HFGRTR_EL2", "x");
+}
+
+impl Writeable for Reg {
+    type T = u64;
+    type R = ();
+
+    sys_coproc_write_raw!(u64, "HFGRTR_EL2", "x");
+}
+
+pub const HFGRTR_EL2: Reg = Reg;


### PR DESCRIPTION
Hypervisor Fault Group Register - EL2
Provides implementation-defined configuration and control options for execution at EL2.