### PR TITLE
Update `tock-registers` 0.9.0 -> 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ exclude = [
 ]
 
 [dependencies]
-tock-registers = { version = "0.9.0", default-features = false } # Use it as interface-only library.
+tock-registers = { version = "0.10.0", default-features = false } # Use it as interface-only library.


### PR DESCRIPTION
The only breaking change mentioned in the [CHANGELOG](https://github.com/tock/tock/blob/master/libraries/tock-register-interface/CHANGELOG.md#breaking-changes) concerns custom implementations of `UIntLike`, which this crate does not seem to have.