### PR TITLE
Fix EC field TrappedFP annotation.

### DIFF
--- a/src/registers/esr_el1.rs
+++ b/src/registers/esr_el1.rs
@@ -38,7 +38,7 @@ register_bitfields! {u64,
             TrappedMCRorMRC2 = 0b00_0101,
             /// Trapped LDC or STC access (FEAT_AA32)
             TrappedLDCorSTC = 0b00_0110,
-            /// Access to SME, SVE, Advanced SIMD or floating-point functionality trapped
+            /// Access to SME, SVE, Advanced SIMD or floating-point functionality trapped (FEAT_AA32)
             TrappedFP = 0b00_0111,
             /// Trapped execution of any instruction not covered by other EC values (FEAT_LS64)
             TrappedNotCovered = 0b00_1010,
@@ -46,7 +46,7 @@ register_bitfields! {u64,
             TrappedMRRC = 0b00_1100,
             /// Branch Target Exception (FEAT_BTI)
             BranchTarget = 0b00_1101,
-            /// Illegal Execution state (FEAT_BTI)
+            /// Illegal Execution state
             IllegalExecutionState = 0b00_1110,
             /// SVC instruction execution in AArch32 state (FEAT_AA32)
             SVC32 = 0b01_0001,

--- a/src/registers/esr_el2.rs
+++ b/src/registers/esr_el2.rs
@@ -50,7 +50,7 @@ register_bitfields! {u64,
             TrappedMCRorMRC2 = 0b00_0101,
             /// Trapped LDC or STC access (FEAT_AA32)
             TrappedLDCorSTC = 0b00_0110,
-            /// Access to SME, SVE, Advanced SIMD or floating-point functionality trapped
+            /// Access to SME, SVE, Advanced SIMD or floating-point functionality trapped (FEAT_AA32)
             TrappedFP = 0b00_0111,
             /// Trapped VMRS access, from ID group trap (FEAT_AA32)
             TrappedVMRS = 0b00_1000,


### PR DESCRIPTION
TrappedFP also only available for FEAT_AA32.

Originally posted by @thejpster in https://github.com/rust-embedded/aarch64-cpu/pull/60#discussion_r2576351970

Fixed issue #62 