### PR TITLE
Adds additional Armv8-R AArch64 example programs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ exclude = [
 
 [dependencies]
 tock-registers = { version = "0.10.0", default-features = false } # Use it as interface-only library.
+critical-section = { version = "1.2.0", features = ["restore-state-u8"], optional = true }
+
+[features]
+critical-section-single-core = ["critical-section"]

--- a/examples/armv8-r/.cargo/config.toml
+++ b/examples/armv8-r/.cargo/config.toml
@@ -6,3 +6,6 @@ runner = "FVP_BaseR_AEMv8R -f fvp_cfg.txt"
 
 [unstable]
 build-std = ["core", "compiler_builtins"]
+
+[env]
+DEFMT_LOG = "info"

--- a/examples/armv8-r/.gitignore
+++ b/examples/armv8-r/.gitignore
@@ -1,1 +1,2 @@
 !/Cargo.lock
+/uart0.out

--- a/examples/armv8-r/Cargo.lock
+++ b/examples/armv8-r/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "aarch64-cpu"
 version = "11.2.0"
 dependencies = [
+ "critical-section",
  "tock-registers",
 ]
 
@@ -16,22 +17,291 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b64de198c6b65a80f7b8e799c2c9b957de30ef161d676bbc4b52943313bc4f27"
 
 [[package]]
+name = "arm-fvp-base-pac"
+version = "0.1.4"
+source = "git+https://github.com/ArmFirmwareCrates/arm-fvp-base-pac/?rev=9547f29c26cece16434d536b05ca50007e24c0aa#9547f29c26cece16434d536b05ca50007e24c0aa"
+dependencies = [
+ "arm-generic-timer",
+ "arm-gic",
+ "arm-pl011-uart",
+ "arm-sp805",
+ "arm-tzc",
+ "bitflags 2.11.0",
+ "safe-mmio",
+ "spin",
+ "zerocopy",
+]
+
+[[package]]
+name = "arm-generic-timer"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebe26eb90fa301b9bd2c44206bf867930fe1a3008b5e01939916908202a52c5"
+dependencies = [
+ "bitflags 2.11.0",
+ "safe-mmio",
+ "zerocopy",
+]
+
+[[package]]
+name = "arm-gic"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c044ecf8760dd8ee5aa92c49cf7534942d289fb1f0247af92b5fbab8ab18a912"
+dependencies = [
+ "bitflags 2.11.0",
+ "safe-mmio",
+ "thiserror",
+ "zerocopy",
+]
+
+[[package]]
+name = "arm-pl011-uart"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62040eef329ede76c8b2af149362b0fd42ec9d8c436d9eb9d47db35b71cb300"
+dependencies = [
+ "bitflags 2.11.0",
+ "embedded-hal-nb",
+ "embedded-io",
+ "safe-mmio",
+ "thiserror",
+ "zerocopy",
+]
+
+[[package]]
+name = "arm-sp805"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "952e2661eff687e263d0bb6acef282092ee729eaea3586f904046f74b49bbe8d"
+dependencies = [
+ "bitflags 2.11.0",
+ "safe-mmio",
+ "zerocopy",
+]
+
+[[package]]
+name = "arm-tzc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "832ef75000f5bad7a50f10d0e3a1ee95ac37988e68f25329157b5aff8dd0842b"
+dependencies = [
+ "bitflags 2.11.0",
+ "safe-mmio",
+ "zerocopy",
+]
+
+[[package]]
 name = "armv8-r"
 version = "0.0.0"
 dependencies = [
  "aarch64-cpu",
  "aarch64-rt",
+ "arm-fvp-base-pac",
+ "arm-gic",
+ "critical-section",
+ "defmt",
  "semihosting",
 ]
 
 [[package]]
-name = "semihosting"
-version = "0.1.24"
+name = "bitflags"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e896488941756e5de3ee8449495464dbbf2201c85d2d1ace47d4fb81c74b99ec"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "defmt"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4fc12a85bcf441cfe44344c4b72d58493178ce635338a3f3b78943aceb258e"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-hal-nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba4268c14288c828995299e59b12babdbe170f6c6d73731af1b4648142e8605"
+dependencies = [
+ "embedded-hal",
+ "nb",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "safe-mmio"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a69f884a1511aa811aa94e04559414a66b18ca63f50f84ca31e304f38bad0d"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "semihosting"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8e4abf97879f4e80db69a9fba7bd64998e9bdad25f58ef045a778e191172fd4"
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tock-registers"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2d250f87fb3fb6f225c907cf54381509f47b40b74b1d1f12d2dccbc915bdfe"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5030500cb2d66bdfbb4ebc9563be6ce7005a4b5d0f26be0c523870fe372ca6"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5f86989a046a79640b9d8867c823349a139367bda96549794fcc3313ce91f4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/examples/armv8-r/Cargo.toml
+++ b/examples/armv8-r/Cargo.toml
@@ -5,8 +5,17 @@ name = "armv8-r"
 publish = false
 
 [dependencies]
-aarch64-rt = { version = "=0.4.0", default-features = false }
-aarch64-cpu.path = "../.."
+aarch64-rt = { version = "=0.4.0", default-features = false, features = [
+    "exceptions",
+] }
+# Use a git hash until a release is put out
+arm-fvp-base-pac = { git = "https://github.com/ArmFirmwareCrates/arm-fvp-base-pac/", rev = "9547f29c26cece16434d536b05ca50007e24c0aa", features = [
+    "base-r",
+] }
+arm-gic = "0.7.2"
+aarch64-cpu = { path = "../..", features = ["critical-section-single-core"] }
+critical-section = "1.2.0"
+defmt = "1.0.1"
 semihosting = { version = "0.1.24", default-features = false, features = [
     "panic-handler",
     "stdio",

--- a/examples/armv8-r/README.md
+++ b/examples/armv8-r/README.md
@@ -18,6 +18,13 @@ This folder contains example programs for the Armv8-R AArch64 architecture.
 
 [1]: https://developer.arm.com/Tools%20and%20Software/Fixed%20Virtual%20Platforms/Arm%20Architecture%20FVPs
 
+* (Optional) `defmt-print` to decode the defmt logs produced by some examples.
+  The tool can be installed with the following command:
+
+``` console
+$ cargo install defmt-print --version 1.0.0 --locked
+```
+
 ## Running the examples
 
 All commands in this section are meant to be executed using this directory as the working directory.
@@ -31,6 +38,54 @@ It also validates that static variables are initialized before the start of `mai
 $ cargo run --bin hello
 Hello, world! running from EL2
 static variables: X=0, Y=1
+```
+
+### `interrupts`
+
+This program showcases nested interrupt handling.
+
+``` console
+$ cargo run --bin interrupts
+start of main
+  > irq_current()
+  Handling SGI 1
+  SGI1 handler
+  before raising SGI0
+    > irq_current()
+    Handling SGI 0
+    SGI0 handler
+    Handled SGI 0
+    < irq_current()
+  after raising SGI0
+  Handled SGI 1
+  < irq_current()
+end of main
+```
+
+### `defmt`
+
+This program showcases defmt logging.
+The defmt logs are output via UART0 (serial port 0) and not printed to the console.
+
+``` console
+$ cargo run --bin defmt
+before defmt log
+before raise SGI0
+after raise SGI0
+  > irq_current()
+  Handling SGI 0
+  Handled SGI 0
+  < irq_current()
+after defmt log
+```
+
+The FVP will create a file named `uart0.out` in the current directory that contains the UART0 output of the program.
+This file is defmt-encoded and can be decoded with the following command:
+
+``` console
+$ cat uart0.out | defmt-print -e target/aarch64v8r-unknown-none/debug/defmt
+INFO  >>> 42 <<<
+INFO  SGI0 handler
 ```
 
 ## License

--- a/examples/armv8-r/build.rs
+++ b/examples/armv8-r/build.rs
@@ -12,6 +12,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // linker script provided by aarch64-rt
     println!("cargo:rustc-link-arg=-Timage.ld");
+    // linker script provided by defmt
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
 
     Ok(())
 }

--- a/examples/armv8-r/fvp_cfg.txt
+++ b/examples/armv8-r/fvp_cfg.txt
@@ -12,3 +12,10 @@ cluster0.gicv3.cpuintf-mmap-access-level = 2
 cluster0.gicv3.SRE-enable-action-on-mmap = 2
 cluster0.gicv3.SRE-EL2-enable-RAO = 1
 cluster0.gicv3.extended-interrupt-range-support = 1
+
+# for defmt
+bp.pl011_uart0.out_file=uart0.out
+bp.pl011_uart0.uart_enable=1
+bp.pl011_uart0.unbuffered_output=1
+bp.terminal_0.mode=raw
+bp.terminal_0.start_telnet=0

--- a/examples/armv8-r/src/bin/defmt.rs
+++ b/examples/armv8-r/src/bin/defmt.rs
@@ -1,0 +1,72 @@
+#![no_main]
+#![no_std]
+
+use aarch64_rt::{ExceptionHandlers, RegisterStateRef, entry, exception_handlers};
+use semihosting::{println, process};
+
+use armv8_r::{
+    Peripherals,
+    fmt::Nesting,
+    gic::{Gic, IntId},
+};
+
+entry!(main);
+
+const INTID_SGI0: IntId = IntId::sgi(0);
+
+fn main(_arg0: u64, _arg1: u64, _arg2: u64, _arg3: u64) -> ! {
+    let Peripherals { mut gic } = Peripherals::take();
+
+    gic.set_interrupt_priority(INTID_SGI0, 1);
+
+    let enabled = true;
+    gic.enable_interrupt(INTID_SGI0, enabled);
+
+    arm_gic::irq_enable();
+
+    gic.set_priority_mask(0);
+
+    println!("before defmt log");
+    defmt::info!(">>> {} <<<", SendSgi(42));
+    println!("after defmt log");
+
+    process::exit(0)
+}
+
+struct SendSgi(i32);
+
+impl defmt::Format for SendSgi {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        println!("before raise SGI0");
+        // this interrupt should be withheld until the defmt logger is released
+        Gic::send_sgi(INTID_SGI0);
+        println!("after raise SGI0");
+        self.0.format(f);
+    }
+}
+
+exception_handlers!(Exceptions);
+struct Exceptions;
+impl ExceptionHandlers for Exceptions {
+    extern "C" fn irq_current(_register_state: RegisterStateRef<'_>) {
+        let _guard = Nesting::increase();
+        println!("{Nesting}> irq_current()");
+        while let Some(int_id) = Gic::get_and_acknowledge_interrupt() {
+            println!("{Nesting}Handling {:?}", int_id);
+            arm_gic::irq_enable();
+            if int_id == INTID_SGI0 {
+                handle_sgi0_irq();
+            } else {
+                unimplemented!()
+            }
+            arm_gic::irq_disable();
+            println!("{Nesting}Handled {:?}", int_id);
+            Gic::end_interrupt(int_id);
+            println!("{Nesting}< irq_current()");
+        }
+    }
+}
+
+fn handle_sgi0_irq() {
+    defmt::info!("SGI0 handler")
+}

--- a/examples/armv8-r/src/bin/hello.rs
+++ b/examples/armv8-r/src/bin/hello.rs
@@ -4,7 +4,7 @@
 use core::sync::atomic::{self, AtomicU64};
 
 use aarch64_cpu::registers::{self, Readable};
-use aarch64_rt::entry;
+use aarch64_rt::{ExceptionHandlers, entry, exception_handlers};
 use semihosting::{println, process};
 
 static X: AtomicU64 = AtomicU64::new(0);
@@ -26,3 +26,8 @@ fn main(_arg0: u64, _arg1: u64, _arg2: u64, _arg3: u64) -> ! {
 
     process::exit(0)
 }
+
+// needed by aarch64-rt even when not used
+exception_handlers!(Exceptions);
+struct Exceptions;
+impl ExceptionHandlers for Exceptions {}

--- a/examples/armv8-r/src/bin/interrupts.rs
+++ b/examples/armv8-r/src/bin/interrupts.rs
@@ -1,0 +1,86 @@
+//! Example of nested Software Generated Interrupts (SGI)
+
+#![no_main]
+#![no_std]
+
+use aarch64_rt::{ExceptionHandlers, RegisterStateRef, entry, exception_handlers};
+use semihosting::{println, process};
+
+use armv8_r::{
+    Peripherals,
+    fmt::Nesting,
+    gic::{Gic, IntId},
+};
+
+entry!(main);
+
+const INTID_SGI0: IntId = IntId::sgi(0);
+const INTID_SGI1: IntId = IntId::sgi(1);
+
+fn main(_arg0: u64, _arg1: u64, _arg2: u64, _arg3: u64) -> ! {
+    println!("start of main");
+
+    let Peripherals { mut gic } = Peripherals::take();
+
+    let interrupts_and_priorities = [(INTID_SGI0, 2), (INTID_SGI1, 1)];
+    for (intid, logical_prio) in interrupts_and_priorities {
+        gic.set_interrupt_priority(intid, logical_prio);
+    }
+
+    let enabled = true;
+    for (intid, _logical_prio) in interrupts_and_priorities {
+        gic.enable_interrupt(intid, enabled);
+    }
+
+    // needed because ISA exceptions handlers (e.g. IRQ) are masked out of boot
+    arm_gic::irq_enable();
+
+    // on boot this is set to the highest logical priority which masks all interrupts, so
+    // it needs to be loosened
+    gic.set_priority_mask(0);
+
+    Gic::send_sgi(INTID_SGI1);
+
+    println!("end of main");
+
+    process::exit(0)
+}
+
+exception_handlers!(Exceptions);
+struct Exceptions;
+impl ExceptionHandlers for Exceptions {
+    extern "C" fn irq_current(_register_state: RegisterStateRef<'_>) {
+        let _guard = Nesting::increase();
+        println!("{Nesting}> irq_current()");
+
+        while let Some(int_id) = Gic::get_and_acknowledge_interrupt() {
+            println!("{Nesting}Handling {:?}", int_id);
+
+            arm_gic::irq_enable();
+            if int_id == INTID_SGI0 {
+                handle_sgi0_irq();
+            } else if int_id == INTID_SGI1 {
+                handle_sgi1_irq();
+            } else {
+                unimplemented!()
+            }
+            arm_gic::irq_disable();
+
+            println!("{Nesting}Handled {:?}", int_id);
+            Gic::end_interrupt(int_id);
+            println!("{Nesting}< irq_current()");
+        }
+    }
+}
+
+fn handle_sgi0_irq() {
+    println!("{Nesting}SGI0 handler")
+}
+
+fn handle_sgi1_irq() {
+    println!("{Nesting}SGI1 handler");
+
+    println!("{Nesting}before raising SGI0");
+    Gic::send_sgi(INTID_SGI0);
+    println!("{Nesting}after raising SGI0");
+}

--- a/examples/armv8-r/src/fmt.rs
+++ b/examples/armv8-r/src/fmt.rs
@@ -1,0 +1,35 @@
+use core::{
+    fmt,
+    sync::atomic::{self, AtomicUsize},
+};
+
+pub struct Nesting;
+
+impl Nesting {
+    pub fn increase() -> NestingGuard {
+        NESTING.fetch_add(1, atomic::Ordering::Relaxed);
+        NestingGuard { _inner: () }
+    }
+}
+
+pub struct NestingGuard {
+    _inner: (),
+}
+
+static NESTING: AtomicUsize = AtomicUsize::new(0);
+
+impl fmt::Display for Nesting {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let nesting = NESTING.load(atomic::Ordering::Relaxed);
+        for _ in 0..nesting {
+            f.write_str("  ")?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for NestingGuard {
+    fn drop(&mut self) {
+        NESTING.fetch_sub(1, atomic::Ordering::Relaxed);
+    }
+}

--- a/examples/armv8-r/src/gic.rs
+++ b/examples/armv8-r/src/gic.rs
@@ -1,0 +1,111 @@
+use core::ptr::NonNull;
+
+use aarch64_cpu::registers::{self, ReadWriteable as _, Readable as _};
+use arm_fvp_base_pac::PhysicalInstance;
+pub use arm_gic::IntId;
+use arm_gic::{
+    UniqueMmioPointer,
+    gicv3::{
+        GicCpuInterface, GicV3, InterruptGroup, SgiTarget, SgiTargetGroup,
+        registers::{Gicd, GicrSgi},
+    },
+};
+
+pub struct Gic {
+    inner: GicV3<'static>,
+    priority_bits: u8,
+}
+
+const BOOT_CORE: usize = 0;
+const NUM_CORES: usize = 1;
+
+impl Gic {
+    pub(super) fn setup(gicd: PhysicalInstance<Gicd>, gicr: PhysicalInstance<GicrSgi>) -> Self {
+        let mut gic = {
+            let gicd =
+                unsafe { UniqueMmioPointer::new(NonNull::new(gicd.pa() as *mut _).unwrap()) };
+            let gicr = NonNull::new(gicr.pa() as *mut _).unwrap();
+
+            let is_gicv4 = false; // only has GICv3
+            unsafe { GicV3::new(gicd, gicr, NUM_CORES, is_gicv4) }
+        };
+        // this also enables "interrupt group 1"
+        gic.setup(BOOT_CORE);
+
+        let in_el2 = registers::CurrentEL.read_as_enum(registers::CurrentEL::EL)
+            == Some(registers::CurrentEL::EL::Value::EL2);
+        if in_el2 {
+            // set 'Trap General Exceptions' bit
+            // "All exceptions that would be routed to EL1 are routed to EL2"
+            // without this (off by default) EL2 won't see the IRQ trigger
+            registers::HCR_EL2.modify(registers::HCR_EL2::TGE::SET);
+        }
+
+        // sanity check that we installed the exception handlers
+        let vbar = if in_el2 {
+            registers::VBAR_EL2.get()
+        } else {
+            registers::VBAR_EL1.get()
+        };
+        assert_ne!(
+            0, vbar,
+            "exception handlers have not been installed (check aarch64-rt.features)"
+        );
+
+        GicCpuInterface::set_priority_mask(!0);
+        let mask = GicCpuInterface::get_priority_mask();
+        let priority_bits = mask.count_ones() as u8;
+        Self {
+            inner: gic,
+            priority_bits,
+        }
+    }
+
+    pub fn get_and_acknowledge_interrupt() -> Option<IntId> {
+        GicCpuInterface::get_and_acknowledge_interrupt(InterruptGroup::Group1)
+    }
+
+    pub fn end_interrupt(int_id: IntId) {
+        GicCpuInterface::end_interrupt(int_id, InterruptGroup::Group1);
+    }
+
+    pub fn send_sgi(int_id: IntId) {
+        let dont_care = 0;
+        let target_self = SgiTarget::List {
+            affinity3: dont_care,
+            affinity2: dont_care,
+            affinity1: dont_care,
+            target_list: 1 << BOOT_CORE,
+        };
+
+        GicCpuInterface::send_sgi(int_id, target_self, SgiTargetGroup::CurrentGroup1)
+            .expect("send_sgi");
+    }
+
+    pub fn set_priority_mask(&self, logical_prio: u8) {
+        GicCpuInterface::set_priority_mask(self.logical2hw(logical_prio));
+    }
+
+    pub fn set_interrupt_priority(&mut self, int_id: IntId, logical_priority: u8) {
+        self.inner
+            .set_interrupt_priority(int_id, Some(BOOT_CORE), self.logical2hw(logical_priority))
+            .expect("set_interrupt_priority");
+    }
+
+    pub fn enable_interrupt(&mut self, int_id: IntId, enabled: bool) {
+        self.inner
+            .enable_interrupt(int_id, Some(BOOT_CORE), enabled)
+            .expect("enable_interrupt");
+    }
+
+    fn logical2hw(&self, logical_priority: u8) -> u8 {
+        let max_logical = (1 << self.priority_bits) - 1;
+        assert!(
+            logical_priority <= max_logical,
+            "this logical priority is not supported ({} bits)",
+            self.priority_bits
+        );
+
+        (max_logical - logical_priority) << (8 - self.priority_bits)
+    }
+}

--- a/examples/armv8-r/src/lib.rs
+++ b/examples/armv8-r/src/lib.rs
@@ -1,0 +1,27 @@
+#![no_std]
+
+pub mod fmt;
+pub mod gic;
+mod uart;
+
+use crate::gic::Gic;
+
+/// Subset of FVP peripherals used by the examples
+pub struct Peripherals {
+    pub gic: Gic,
+}
+
+impl Peripherals {
+    /// Takes owning handles to the available peripherals
+    pub fn take() -> Self {
+        let arm_fvp_base_pac::Peripherals {
+            gicd, gicr, uart0, ..
+        } = arm_fvp_base_pac::Peripherals::take().expect("peripherals have already been taken");
+        // used by defmt logger; do not use it for anything else
+        drop(uart0);
+
+        Self {
+            gic: Gic::setup(gicd, gicr),
+        }
+    }
+}

--- a/examples/armv8-r/src/uart.rs
+++ b/examples/armv8-r/src/uart.rs
@@ -1,0 +1,125 @@
+//! A defmt logger over UART0
+
+use core::{
+    cell::UnsafeCell,
+    ptr::NonNull,
+    sync::atomic::{self, AtomicBool},
+};
+
+use arm_fvp_base_pac::{UniqueMmioPointer, arm_pl011_uart::Uart};
+use critical_section::RestoreState;
+
+#[defmt::global_logger]
+struct Logger;
+
+static DEFMT_UART: DefmtUart = DefmtUart::new();
+
+struct DefmtUart {
+    encoder: UnsafeCell<defmt::Encoder>,
+    taken: AtomicBool,
+    cs_restore: UnsafeCell<RestoreState>,
+}
+
+impl DefmtUart {
+    const fn new() -> Self {
+        Self {
+            encoder: UnsafeCell::new(defmt::Encoder::new()),
+            taken: AtomicBool::new(false),
+            cs_restore: UnsafeCell::new(RestoreState::invalid()),
+        }
+    }
+
+    fn acquire(&self) {
+        let restore = unsafe { critical_section::acquire() };
+
+        if self.taken.load(atomic::Ordering::Relaxed) {
+            panic!("defmt logger taken reentrantly")
+        }
+
+        self.taken.store(true, atomic::Ordering::Relaxed);
+
+        // SAFETY: inside a critical section
+        unsafe {
+            self.cs_restore.get().write(restore);
+            (*self.encoder.get()).start_frame(|encoded| {
+                for byte in encoded {
+                    write_byte(*byte)
+                }
+            })
+        }
+    }
+
+    unsafe fn flush(&self) {
+        // no action
+    }
+
+    unsafe fn release(&self) {
+        if !self.taken.load(atomic::Ordering::Relaxed) {
+            // release out of context
+            return;
+        }
+
+        // SAFETY: inside a critical section
+        unsafe {
+            (*self.encoder.get()).end_frame(|encoded| {
+                for byte in encoded {
+                    write_byte(*byte)
+                }
+            })
+        }
+
+        // this flag needs to be cleared before interrupts are allowd to rerun or they may
+        // hit the 'taken reentrantly' panic branch in `acquire`
+        self.taken.store(false, atomic::Ordering::Relaxed);
+        // end of critical section
+        unsafe {
+            let restore = self.cs_restore.get().read();
+            critical_section::release(restore);
+        }
+    }
+
+    unsafe fn write(&self, bytes: &[u8]) {
+        if !self.taken.load(atomic::Ordering::Relaxed) {
+            // write out of critical section
+            return;
+        }
+
+        // SAFETY: inside a critical section
+        unsafe {
+            (*self.encoder.get()).write(bytes, |encoded| {
+                for byte in encoded {
+                    write_byte(*byte)
+                }
+            })
+        }
+    }
+}
+
+unsafe impl defmt::Logger for Logger {
+    fn acquire() {
+        DEFMT_UART.acquire()
+    }
+
+    unsafe fn flush() {
+        unsafe { DEFMT_UART.flush() }
+    }
+
+    unsafe fn release() {
+        unsafe { DEFMT_UART.release() }
+    }
+
+    unsafe fn write(bytes: &[u8]) {
+        unsafe { DEFMT_UART.write(bytes) }
+    }
+}
+
+unsafe impl Sync for DefmtUart {}
+
+fn write_byte(byte: u8) {
+    // SAFETY: this UART instance is only used from within this critical section
+    let uart0 = unsafe { arm_fvp_base_pac::Peripherals::steal().uart0 };
+    let mut uart =
+        Uart::new(unsafe { UniqueMmioPointer::new(NonNull::new(uart0.pa() as *mut _).unwrap()) });
+
+    uart.write_word(byte);
+}

--- a/src/critical_section.rs
+++ b/src/critical_section.rs
@@ -1,0 +1,38 @@
+#[cfg(feature = "critical-section-single-core")]
+mod single_core {
+    use core::sync::atomic;
+
+    use crate::registers::{self, Readable, Writeable};
+
+    struct SingleCoreCriticalSection;
+
+    critical_section::set_impl!(SingleCoreCriticalSection);
+
+    const DAIF_OFFSET: usize = 6;
+
+    unsafe impl critical_section::Impl for SingleCoreCriticalSection {
+        unsafe fn acquire() -> critical_section::RawRestoreState {
+            let daif_bits = registers::DAIF.get();
+
+            registers::DAIF.write(
+                registers::DAIF::D::Masked
+                    + registers::DAIF::A::Masked
+                    + registers::DAIF::I::Masked
+                    + registers::DAIF::F::Masked,
+            );
+
+            // prevent reordering across the preceding register write
+            atomic::compiler_fence(atomic::Ordering::SeqCst);
+
+            // shift DAIF value (only 4 contiguous bits are used) to fit into `u8`
+            (daif_bits >> DAIF_OFFSET) as u8
+        }
+
+        unsafe fn release(daif_bits: critical_section::RawRestoreState) {
+            // prevent reordering across the following register write
+            atomic::compiler_fence(atomic::Ordering::SeqCst);
+
+            registers::DAIF.set((daif_bits << DAIF_OFFSET) as u64);
+        }
+    }
+}

--- a/src/critical_section.rs
+++ b/src/critical_section.rs
@@ -12,27 +12,27 @@ mod single_core {
 
     unsafe impl critical_section::Impl for SingleCoreCriticalSection {
         unsafe fn acquire() -> critical_section::RawRestoreState {
-            let daif_bits = registers::DAIF.get();
+            // get which of DAIF are currently masked (shift to fit into `u8`)
+            let daif_bits = registers::DAIF.get() >> DAIF_OFFSET;
 
-            registers::DAIF.write(
-                registers::DAIF::D::Masked
-                    + registers::DAIF::A::Masked
-                    + registers::DAIF::I::Masked
-                    + registers::DAIF::F::Masked,
-            );
+            // mask everything (even if already masked)
+            registers::DAIFSet.set(0b1111);
 
             // prevent reordering across the preceding register write
             atomic::compiler_fence(atomic::Ordering::SeqCst);
 
-            // shift DAIF value (only 4 contiguous bits are used) to fit into `u8`
-            (daif_bits >> DAIF_OFFSET) as u8
+            // record which DAIF bits we need to clear later (only clear the ones that were not
+            // masked)
+            let bits_to_clear = daif_bits ^ 0b1111;
+            bits_to_clear as u8
         }
 
-        unsafe fn release(daif_bits: critical_section::RawRestoreState) {
+        unsafe fn release(bits_to_clear: critical_section::RawRestoreState) {
             // prevent reordering across the following register write
             atomic::compiler_fence(atomic::Ordering::SeqCst);
 
-            registers::DAIF.set((daif_bits << DAIF_OFFSET) as u64);
+            // unmask the relevant DAIF bits
+            registers::DAIFClr.set(bits_to_clear as u64);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,4 +56,5 @@
 #![no_std]
 
 pub mod asm;
+mod critical_section;
 pub mod registers;

--- a/src/registers/afsr0_el1.rs
+++ b/src/registers/afsr0_el1.rs
@@ -7,7 +7,8 @@
 
 //! Auxiliary Fault Status Register 0 - EL1
 //!
-//! Provides IMPLEMENTATION DEFINED fault status information for synchronous aborts that are taken to EL1.
+//! Provides IMPLEMENTATION DEFINED fault status information for synchronous aborts that are taken
+//! to EL1.
 
 use tock_registers::interfaces::{Readable, Writeable};
 

--- a/src/registers/afsr1_el1.rs
+++ b/src/registers/afsr1_el1.rs
@@ -7,7 +7,8 @@
 
 //! Auxiliary Fault Status Register 1 - EL1
 //!
-//! Provides IMPLEMENTATION DEFINED fault status information for synchronous aborts that are taken to EL1.
+//! Provides IMPLEMENTATION DEFINED fault status information for synchronous aborts that are taken
+//! to EL1.
 
 use tock_registers::interfaces::{Readable, Writeable};
 

--- a/src/registers/mdscr_el1.rs
+++ b/src/registers/mdscr_el1.rs
@@ -9,7 +9,8 @@
 //!
 //! Main control register for debug functions.
 //!
-//! This register is present only when FEAT_AA64 is implemented. Otherwise, direct accesses to MDSCR_EL1 are UNDEFINED.
+//! This register is present only when FEAT_AA64 is implemented. Otherwise, direct accesses to
+//! MDSCR_EL1 are UNDEFINED.
 
 use tock_registers::{
     interfaces::{Readable, Writeable},

--- a/src/registers/vmpidr_el2.rs
+++ b/src/registers/vmpidr_el2.rs
@@ -9,8 +9,10 @@
 //!
 //! Holds the value returned for EL1 reads of MPIDR_EL1.
 
-use tock_registers::interfaces::Writeable;
-use tock_registers::{interfaces::Readable, register_bitfields};
+use tock_registers::{
+    interfaces::{Readable, Writeable},
+    register_bitfields,
+};
 
 register_bitfields! {u64,
     pub VMPIDR_EL2 [


### PR DESCRIPTION
This PR adds additional Armv8-R AArch64 example programs, along with a single-core critical section implementation. The examples expand upon the existing *Hello, World* example and demonstrate the use of the Arm Generic Interrupt Controller and logging using defmt via the PL011 UART.

This PR was developed by Ferrous Systems on behalf of Arm. Arm is the owner of these changes.

~~Currently this PR is using a patched copy of `arm-fvp-base-pac` (changes at https://review.trustedfirmware.org/c/arm-firmware-crates/arm-fvp-base-pac/+/49345/2) to support the BaseR FVP memory map. I will undraft once that is accepted.~~

Changes to arm-fvp-base-pac available at https://github.com/ArmFirmwareCrates/arm-fvp-base-pac.