### PR TITLE
Add TLBI (TLB Invalidate) instruction wrappers with typed operands

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -10,6 +10,7 @@
 
 pub mod barrier;
 pub mod random;
+pub mod tlbi;
 
 /// The classic no-op
 #[inline(always)]

--- a/src/asm/tlbi.rs
+++ b/src/asm/tlbi.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
-// Copyright (c) 2018-2026 by the author(s)
+// Copyright (c) 2026 by the author(s)
 //
 // Author(s):
 //   - ZhiHong Niu <zhihong@nzhnb.com>
@@ -10,15 +10,12 @@
 //! Provides Rust wrappers around AArch64 TLBI system instructions for
 //! invalidating TLB entries at EL1.
 //!
-//! # Operand Encoding
+//! # Operand Types
 //!
-//! For address-based TLBI operations (`vae1`, `vale1`, `vaae1`, `vaale1`),
-//! the `u64` operand is encoded as specified in the Arm ARM:
-//!
-//! - Bits \[55:48\]: ASID (for non-"AA" variants)
-//! - Bits \[43:0\]: VA\[55:12\] (the virtual address shifted right by 12)
-//!
-//! It is the caller's responsibility to construct the operand correctly.
+//! | Type | Fields | Used by |
+//! |------|--------|---------|
+//! | [`Addr`] | VA and ASID | `vae1`, `vale1`, `vaae1`, `vaale1` + IS variants |
+//! | [`Asid`] | ASID only | `aside1` + IS variant |
 //!
 //! # Synchronization
 //!
@@ -37,275 +34,231 @@
 //! use aarch64_cpu::asm::{barrier, tlbi};
 //!
 //! // Invalidate all EL1&0 regime TLB entries.
-//! // A DSB before ensures prior stores to page tables are visible;
-//! // a DSB+ISB after ensures the invalidation completes before
-//! // subsequent memory accesses.
 //! barrier::dsb(barrier::SY);
 //! tlbi::vmalle1();
 //! barrier::dsb(barrier::SY);
 //! barrier::isb(barrier::SY);
 //!
-//! // Invalidate by VA: encode operand as VA[55:12] | (ASID << 48).
-//! let vaddr: u64 = 0x8000_0000;
-//! let asid: u64 = 1;
-//! let operand = (vaddr >> 12) | (asid << 48);
+//! // Invalidate by VA + ASID.
 //! barrier::dsb(barrier::SY);
-//! tlbi::vae1(operand);
+//! tlbi::vae1(tlbi::Addr::new(0x8000_0000, 1));
+//! barrier::dsb(barrier::SY);
+//! barrier::isb(barrier::SY);
+//!
+//! // Invalidate by VA, all ASIDs (pass ASID = 0).
+//! barrier::dsb(barrier::SY);
+//! tlbi::vaae1(tlbi::Addr::new(0x8000_0000, 0));
+//! barrier::dsb(barrier::SY);
+//! barrier::isb(barrier::SY);
+//!
+//! // Invalidate by ASID.
+//! barrier::dsb(barrier::SY);
+//! tlbi::aside1(tlbi::Asid::new(1));
 //! barrier::dsb(barrier::SY);
 //! barrier::isb(barrier::SY);
 //! ```
+//!
+//! # Future Work
+//!
+//! - FEAT_TTL (ARMv8.4): Allow setting the TTL hint in bits \[47:44\] of
+//!   [`Addr`] for more efficient invalidation when the page table level
+//!   is known.
+//! - FEAT_TLBIRANGE (ARMv8.4): Add range-based TLBI instructions
+//!   (`RVAE1`, `RVALE1`, etc.) with their distinct operand encoding.
+//! - Outer Shareable variants (ARMv8.4): `VMALLE1OS`, `VAE1OS`,
+//!   `VALE1OS`, etc.
 
-/// Invalidate all EL1&0 regime TLB entries in the current VMID.
+/// Encoded TLBI operand carrying a virtual address and ASID.
 ///
-/// Executes `TLBI VMALLE1`.
-#[inline(always)]
-pub fn vmalle1() {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI VMALLE1", options(nostack)) },
+/// Layout per Arm ARM:
+/// - Bits \[43:0\]: VA\[55:12\] (virtual address shifted right by 12)
+/// - Bits \[47:44\]: RES0 (or TTL hint when FEAT_TTL is implemented)
+/// - Bits \[63:48\]: ASID (8 or 16 bits depending on `TCR_EL1.AS`)
+///
+/// For use with [`vae1`], [`vae1is`], [`vale1`], [`vale1is`],
+/// [`vaae1`], [`vaae1is`], [`vaale1`], [`vaale1is`].
+///
+/// For all-ASID variants (`vaae1`, `vaale1`, etc.) where the ASID
+/// field is ignored by hardware, pass `asid = 0`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Addr(u64);
 
-        #[cfg(not(target_arch = "aarch64"))]
-        () => unimplemented!(),
+impl Addr {
+    /// VA field mask: bits [43:0].
+    const VA_MASK: u64 = 0x0000_0FFF_FFFF_FFFF;
+
+    /// Encode from a virtual address and ASID.
+    ///
+    /// The low 12 bits of `va` are discarded (the hardware operates on
+    /// page-number granularity).
+    #[inline(always)]
+    pub const fn new(va: u64, asid: u16) -> Self {
+        Self(((va >> 12) & Self::VA_MASK) | ((asid as u64) << 48))
+    }
+
+    /// Construct from a pre-encoded raw value.
+    #[inline(always)]
+    pub const fn from_raw(val: u64) -> Self {
+        Self(val)
+    }
+
+    /// Return the raw encoded value.
+    #[inline(always)]
+    pub const fn as_raw(self) -> u64 {
+        self.0
     }
 }
 
-/// Invalidate all EL1&0 regime TLB entries in the current VMID
-/// on all PEs in the same Inner Shareable domain.
+/// Encoded TLBI operand carrying an ASID only.
 ///
-/// Executes `TLBI VMALLE1IS`.
-#[inline(always)]
-pub fn vmalle1is() {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI VMALLE1IS", options(nostack)) },
+/// Layout per Arm ARM:
+/// - Bits \[47:0\]: RES0
+/// - Bits \[63:48\]: ASID (8 or 16 bits depending on `TCR_EL1.AS`)
+///
+/// For use with [`aside1`], [`aside1is`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Asid(u64);
 
-        #[cfg(not(target_arch = "aarch64"))]
-        () => unimplemented!(),
+impl Asid {
+    /// Encode from an ASID value.
+    #[inline(always)]
+    pub const fn new(asid: u16) -> Self {
+        Self((asid as u64) << 48)
+    }
+
+    /// Construct from a pre-encoded raw value.
+    #[inline(always)]
+    pub const fn from_raw(val: u64) -> Self {
+        Self(val)
+    }
+
+    /// Return the raw encoded value.
+    #[inline(always)]
+    pub const fn as_raw(self) -> u64 {
+        self.0
     }
 }
 
-/// Invalidate TLB entries by VA, EL1&0, current VMID.
-///
-/// Executes `TLBI VAE1, <Xt>`.
-///
-/// # Operand Encoding
-///
-/// - Bits \[55:48\]: ASID
-/// - Bits \[43:0\]: VA\[55:12\]
-#[inline(always)]
-pub fn vae1(val: u64) {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI VAE1, {v}", v = in(reg) val, options(nostack)) },
+// Generate TLBI instruction wrappers that take no operand.
+macro_rules! tlbi_no_arg {
+    ($($(#[$attr:meta])* $fn_name:ident, $inst:tt;)*) => {
+        $(
+            $(#[$attr])*
+            #[inline(always)]
+            pub fn $fn_name() {
+                #[cfg(target_arch = "aarch64")]
+                unsafe {
+                    core::arch::asm!(concat!("TLBI ", stringify!($inst)), options(nostack))
+                }
 
-        #[cfg(not(target_arch = "aarch64"))]
-        () => {
-            let _ = val;
-            unimplemented!()
-        }
-    }
+                #[cfg(not(target_arch = "aarch64"))]
+                unimplemented!()
+            }
+        )*
+    };
 }
 
-/// Invalidate TLB entries by VA, EL1&0, current VMID,
-/// Inner Shareable.
-///
-/// Executes `TLBI VAE1IS, <Xt>`.
-///
-/// # Operand Encoding
-///
-/// - Bits \[55:48\]: ASID
-/// - Bits \[43:0\]: VA\[55:12\]
-#[inline(always)]
-pub fn vae1is(val: u64) {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI VAE1IS, {v}", v = in(reg) val, options(nostack)) },
+// Generate TLBI instruction wrappers that take a typed operand.
+macro_rules! tlbi_arg {
+    ($($(#[$attr:meta])* $fn_name:ident, $inst:tt, $arg_type:ty, $arg_name:ident;)*) => {
+        $(
+            $(#[$attr])*
+            #[inline(always)]
+            pub fn $fn_name($arg_name: $arg_type) {
+                #[cfg(target_arch = "aarch64")]
+                unsafe {
+                    core::arch::asm!(
+                        concat!("TLBI ", stringify!($inst), ", {v}"),
+                        v = in(reg) $arg_name.as_raw(),
+                        options(nostack),
+                    )
+                }
 
-        #[cfg(not(target_arch = "aarch64"))]
-        () => {
-            let _ = val;
-            unimplemented!()
-        }
-    }
+                #[cfg(not(target_arch = "aarch64"))]
+                {
+                    let _ = $arg_name;
+                    unimplemented!()
+                }
+            }
+        )*
+    };
 }
 
-/// Invalidate TLB entries by VA, last level, EL1&0, current VMID.
-///
-/// Executes `TLBI VALE1, <Xt>`.
-///
-/// Only invalidates entries from the last level of the translation
-/// table walk (leaf entries), which can be more efficient than `vae1`
-/// when intermediate entries are known to be unaffected.
-///
-/// # Operand Encoding
-///
-/// - Bits \[55:48\]: ASID
-/// - Bits \[43:0\]: VA\[55:12\]
-#[inline(always)]
-pub fn vale1(val: u64) {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI VALE1, {v}", v = in(reg) val, options(nostack)) },
+tlbi_no_arg! {
+    /// Invalidate all EL1&0 regime TLB entries in the current VMID.
+    ///
+    /// Executes `TLBI VMALLE1`.
+    vmalle1, VMALLE1;
 
-        #[cfg(not(target_arch = "aarch64"))]
-        () => {
-            let _ = val;
-            unimplemented!()
-        }
-    }
+    /// Invalidate all EL1&0 regime TLB entries in the current VMID
+    /// on all PEs in the same Inner Shareable domain.
+    ///
+    /// Executes `TLBI VMALLE1IS`.
+    vmalle1is, VMALLE1IS;
 }
 
-/// Invalidate TLB entries by VA, last level, EL1&0, current VMID,
-/// Inner Shareable.
-///
-/// Executes `TLBI VALE1IS, <Xt>`.
-///
-/// # Operand Encoding
-///
-/// - Bits \[55:48\]: ASID
-/// - Bits \[43:0\]: VA\[55:12\]
-#[inline(always)]
-pub fn vale1is(val: u64) {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI VALE1IS, {v}", v = in(reg) val, options(nostack)) },
+tlbi_arg! {
+    /// Invalidate TLB entries by VA, EL1&0, current VMID.
+    ///
+    /// Executes `TLBI VAE1, <Xt>`.
+    vae1, VAE1, Addr, addr;
 
-        #[cfg(not(target_arch = "aarch64"))]
-        () => {
-            let _ = val;
-            unimplemented!()
-        }
-    }
-}
+    /// Invalidate TLB entries by VA, EL1&0, current VMID,
+    /// Inner Shareable.
+    ///
+    /// Executes `TLBI VAE1IS, <Xt>`.
+    vae1is, VAE1IS, Addr, addr;
 
-/// Invalidate TLB entries by VA, all ASIDs, EL1&0, current VMID.
-///
-/// Executes `TLBI VAAE1, <Xt>`.
-///
-/// Invalidates entries matching the VA regardless of ASID.
-///
-/// # Operand Encoding
-///
-/// - Bits \[43:0\]: VA\[55:12\]
-#[inline(always)]
-pub fn vaae1(val: u64) {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI VAAE1, {v}", v = in(reg) val, options(nostack)) },
+    /// Invalidate TLB entries by VA, last level, EL1&0, current VMID.
+    ///
+    /// Executes `TLBI VALE1, <Xt>`.
+    ///
+    /// Only invalidates entries from the last level of the translation
+    /// table walk (leaf entries), which can be more efficient than [`vae1`]
+    /// when intermediate entries are known to be unaffected.
+    vale1, VALE1, Addr, addr;
 
-        #[cfg(not(target_arch = "aarch64"))]
-        () => {
-            let _ = val;
-            unimplemented!()
-        }
-    }
-}
+    /// Invalidate TLB entries by VA, last level, EL1&0, current VMID,
+    /// Inner Shareable.
+    ///
+    /// Executes `TLBI VALE1IS, <Xt>`.
+    vale1is, VALE1IS, Addr, addr;
 
-/// Invalidate TLB entries by VA, all ASIDs, EL1&0, current VMID,
-/// Inner Shareable.
-///
-/// Executes `TLBI VAAE1IS, <Xt>`.
-///
-/// # Operand Encoding
-///
-/// - Bits \[43:0\]: VA\[55:12\]
-#[inline(always)]
-pub fn vaae1is(val: u64) {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI VAAE1IS, {v}", v = in(reg) val, options(nostack)) },
+    /// Invalidate TLB entries by VA, all ASIDs, EL1&0, current VMID.
+    ///
+    /// Executes `TLBI VAAE1, <Xt>`.
+    ///
+    /// Invalidates entries matching the VA regardless of ASID.
+    vaae1, VAAE1, Addr, addr;
 
-        #[cfg(not(target_arch = "aarch64"))]
-        () => {
-            let _ = val;
-            unimplemented!()
-        }
-    }
-}
+    /// Invalidate TLB entries by VA, all ASIDs, EL1&0, current VMID,
+    /// Inner Shareable.
+    ///
+    /// Executes `TLBI VAAE1IS, <Xt>`.
+    vaae1is, VAAE1IS, Addr, addr;
 
-/// Invalidate TLB entries by VA, all ASIDs, last level, EL1&0,
-/// current VMID.
-///
-/// Executes `TLBI VAALE1, <Xt>`.
-///
-/// # Operand Encoding
-///
-/// - Bits \[43:0\]: VA\[55:12\]
-#[inline(always)]
-pub fn vaale1(val: u64) {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI VAALE1, {v}", v = in(reg) val, options(nostack)) },
+    /// Invalidate TLB entries by VA, all ASIDs, last level, EL1&0,
+    /// current VMID.
+    ///
+    /// Executes `TLBI VAALE1, <Xt>`.
+    vaale1, VAALE1, Addr, addr;
 
-        #[cfg(not(target_arch = "aarch64"))]
-        () => {
-            let _ = val;
-            unimplemented!()
-        }
-    }
-}
+    /// Invalidate TLB entries by VA, all ASIDs, last level, EL1&0,
+    /// current VMID, Inner Shareable.
+    ///
+    /// Executes `TLBI VAALE1IS, <Xt>`.
+    vaale1is, VAALE1IS, Addr, addr;
 
-/// Invalidate TLB entries by VA, all ASIDs, last level, EL1&0,
-/// current VMID, Inner Shareable.
-///
-/// Executes `TLBI VAALE1IS, <Xt>`.
-///
-/// # Operand Encoding
-///
-/// - Bits \[43:0\]: VA\[55:12\]
-#[inline(always)]
-pub fn vaale1is(val: u64) {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI VAALE1IS, {v}", v = in(reg) val, options(nostack)) },
+    /// Invalidate TLB entries by ASID, EL1&0, current VMID.
+    ///
+    /// Executes `TLBI ASIDE1, <Xt>`.
+    aside1, ASIDE1, Asid, asid;
 
-        #[cfg(not(target_arch = "aarch64"))]
-        () => {
-            let _ = val;
-            unimplemented!()
-        }
-    }
-}
-
-/// Invalidate TLB entries by ASID, EL1&0, current VMID.
-///
-/// Executes `TLBI ASIDE1, <Xt>`.
-///
-/// # Operand Encoding
-///
-/// - Bits \[55:48\]: ASID
-#[inline(always)]
-pub fn aside1(val: u64) {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI ASIDE1, {v}", v = in(reg) val, options(nostack)) },
-
-        #[cfg(not(target_arch = "aarch64"))]
-        () => {
-            let _ = val;
-            unimplemented!()
-        }
-    }
-}
-
-/// Invalidate TLB entries by ASID, EL1&0, current VMID,
-/// Inner Shareable.
-///
-/// Executes `TLBI ASIDE1IS, <Xt>`.
-///
-/// # Operand Encoding
-///
-/// - Bits \[55:48\]: ASID
-#[inline(always)]
-pub fn aside1is(val: u64) {
-    match () {
-        #[cfg(target_arch = "aarch64")]
-        () => unsafe { core::arch::asm!("TLBI ASIDE1IS, {v}", v = in(reg) val, options(nostack)) },
-
-        #[cfg(not(target_arch = "aarch64"))]
-        () => {
-            let _ = val;
-            unimplemented!()
-        }
-    }
+    /// Invalidate TLB entries by ASID, EL1&0, current VMID,
+    /// Inner Shareable.
+    ///
+    /// Executes `TLBI ASIDE1IS, <Xt>`.
+    aside1is, ASIDE1IS, Asid, asid;
 }

--- a/src/asm/tlbi.rs
+++ b/src/asm/tlbi.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (c) 2018-2026 by the author(s)
+//
+// Author(s):
+//   - ZhiHong Niu <zhihong@nzhnb.com>
+
+//! TLB Invalidate (TLBI) instructions.
+//!
+//! Provides Rust wrappers around AArch64 TLBI system instructions for
+//! invalidating TLB entries at EL1.
+//!
+//! # Operand Encoding
+//!
+//! For address-based TLBI operations (`vae1`, `vale1`, `vaae1`, `vaale1`),
+//! the `u64` operand is encoded as specified in the Arm ARM:
+//!
+//! - Bits \[55:48\]: ASID (for non-"AA" variants)
+//! - Bits \[43:0\]: VA\[55:12\] (the virtual address shifted right by 12)
+//!
+//! It is the caller's responsibility to construct the operand correctly.
+//!
+//! # Synchronization
+//!
+//! TLBI instructions must be surrounded by appropriate barrier instructions
+//! (DSB before and DSB+ISB after) to ensure the invalidation takes effect.
+//! See [`barrier`](super::barrier).
+//!
+//! # References
+//!
+//! - [Arm ARM §C5.5 - A64 system instructions for TLB maintenance](https://developer.arm.com/documentation/ddi0487/latest)
+//! - [Arm ARM §D8.10 - TLB maintenance instructions](https://developer.arm.com/documentation/ddi0487/latest)
+//!
+//! # Example
+//!
+//! ```no_run
+//! use aarch64_cpu::asm::{barrier, tlbi};
+//!
+//! // Invalidate all EL1&0 regime TLB entries.
+//! // A DSB before ensures prior stores to page tables are visible;
+//! // a DSB+ISB after ensures the invalidation completes before
+//! // subsequent memory accesses.
+//! barrier::dsb(barrier::SY);
+//! tlbi::vmalle1();
+//! barrier::dsb(barrier::SY);
+//! barrier::isb(barrier::SY);
+//!
+//! // Invalidate by VA: encode operand as VA[55:12] | (ASID << 48).
+//! let vaddr: u64 = 0x8000_0000;
+//! let asid: u64 = 1;
+//! let operand = (vaddr >> 12) | (asid << 48);
+//! barrier::dsb(barrier::SY);
+//! tlbi::vae1(operand);
+//! barrier::dsb(barrier::SY);
+//! barrier::isb(barrier::SY);
+//! ```
+
+/// Invalidate all EL1&0 regime TLB entries in the current VMID.
+///
+/// Executes `TLBI VMALLE1`.
+#[inline(always)]
+pub fn vmalle1() {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI VMALLE1", options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => unimplemented!(),
+    }
+}
+
+/// Invalidate all EL1&0 regime TLB entries in the current VMID
+/// on all PEs in the same Inner Shareable domain.
+///
+/// Executes `TLBI VMALLE1IS`.
+#[inline(always)]
+pub fn vmalle1is() {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI VMALLE1IS", options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => unimplemented!(),
+    }
+}
+
+/// Invalidate TLB entries by VA, EL1&0, current VMID.
+///
+/// Executes `TLBI VAE1, <Xt>`.
+///
+/// # Operand Encoding
+///
+/// - Bits \[55:48\]: ASID
+/// - Bits \[43:0\]: VA\[55:12\]
+#[inline(always)]
+pub fn vae1(val: u64) {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI VAE1, {v}", v = in(reg) val, options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => {
+            let _ = val;
+            unimplemented!()
+        }
+    }
+}
+
+/// Invalidate TLB entries by VA, EL1&0, current VMID,
+/// Inner Shareable.
+///
+/// Executes `TLBI VAE1IS, <Xt>`.
+///
+/// # Operand Encoding
+///
+/// - Bits \[55:48\]: ASID
+/// - Bits \[43:0\]: VA\[55:12\]
+#[inline(always)]
+pub fn vae1is(val: u64) {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI VAE1IS, {v}", v = in(reg) val, options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => {
+            let _ = val;
+            unimplemented!()
+        }
+    }
+}
+
+/// Invalidate TLB entries by VA, last level, EL1&0, current VMID.
+///
+/// Executes `TLBI VALE1, <Xt>`.
+///
+/// Only invalidates entries from the last level of the translation
+/// table walk (leaf entries), which can be more efficient than `vae1`
+/// when intermediate entries are known to be unaffected.
+///
+/// # Operand Encoding
+///
+/// - Bits \[55:48\]: ASID
+/// - Bits \[43:0\]: VA\[55:12\]
+#[inline(always)]
+pub fn vale1(val: u64) {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI VALE1, {v}", v = in(reg) val, options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => {
+            let _ = val;
+            unimplemented!()
+        }
+    }
+}
+
+/// Invalidate TLB entries by VA, last level, EL1&0, current VMID,
+/// Inner Shareable.
+///
+/// Executes `TLBI VALE1IS, <Xt>`.
+///
+/// # Operand Encoding
+///
+/// - Bits \[55:48\]: ASID
+/// - Bits \[43:0\]: VA\[55:12\]
+#[inline(always)]
+pub fn vale1is(val: u64) {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI VALE1IS, {v}", v = in(reg) val, options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => {
+            let _ = val;
+            unimplemented!()
+        }
+    }
+}
+
+/// Invalidate TLB entries by VA, all ASIDs, EL1&0, current VMID.
+///
+/// Executes `TLBI VAAE1, <Xt>`.
+///
+/// Invalidates entries matching the VA regardless of ASID.
+///
+/// # Operand Encoding
+///
+/// - Bits \[43:0\]: VA\[55:12\]
+#[inline(always)]
+pub fn vaae1(val: u64) {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI VAAE1, {v}", v = in(reg) val, options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => {
+            let _ = val;
+            unimplemented!()
+        }
+    }
+}
+
+/// Invalidate TLB entries by VA, all ASIDs, EL1&0, current VMID,
+/// Inner Shareable.
+///
+/// Executes `TLBI VAAE1IS, <Xt>`.
+///
+/// # Operand Encoding
+///
+/// - Bits \[43:0\]: VA\[55:12\]
+#[inline(always)]
+pub fn vaae1is(val: u64) {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI VAAE1IS, {v}", v = in(reg) val, options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => {
+            let _ = val;
+            unimplemented!()
+        }
+    }
+}
+
+/// Invalidate TLB entries by VA, all ASIDs, last level, EL1&0,
+/// current VMID.
+///
+/// Executes `TLBI VAALE1, <Xt>`.
+///
+/// # Operand Encoding
+///
+/// - Bits \[43:0\]: VA\[55:12\]
+#[inline(always)]
+pub fn vaale1(val: u64) {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI VAALE1, {v}", v = in(reg) val, options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => {
+            let _ = val;
+            unimplemented!()
+        }
+    }
+}
+
+/// Invalidate TLB entries by VA, all ASIDs, last level, EL1&0,
+/// current VMID, Inner Shareable.
+///
+/// Executes `TLBI VAALE1IS, <Xt>`.
+///
+/// # Operand Encoding
+///
+/// - Bits \[43:0\]: VA\[55:12\]
+#[inline(always)]
+pub fn vaale1is(val: u64) {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI VAALE1IS, {v}", v = in(reg) val, options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => {
+            let _ = val;
+            unimplemented!()
+        }
+    }
+}
+
+/// Invalidate TLB entries by ASID, EL1&0, current VMID.
+///
+/// Executes `TLBI ASIDE1, <Xt>`.
+///
+/// # Operand Encoding
+///
+/// - Bits \[55:48\]: ASID
+#[inline(always)]
+pub fn aside1(val: u64) {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI ASIDE1, {v}", v = in(reg) val, options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => {
+            let _ = val;
+            unimplemented!()
+        }
+    }
+}
+
+/// Invalidate TLB entries by ASID, EL1&0, current VMID,
+/// Inner Shareable.
+///
+/// Executes `TLBI ASIDE1IS, <Xt>`.
+///
+/// # Operand Encoding
+///
+/// - Bits \[55:48\]: ASID
+#[inline(always)]
+pub fn aside1is(val: u64) {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { core::arch::asm!("TLBI ASIDE1IS, {v}", v = in(reg) val, options(nostack)) },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => {
+            let _ = val;
+            unimplemented!()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add Rust wrappers for AArch64 TLBI system instructions at EL1, with typed operand encoding that prevents callers from having to manually shift and mask bit fields.

### Operand types

- `tlbi::Addr` — encodes VA (bits [43:0]) and ASID (bits [63:48]) for VA-based instructions
- `tlbi::Asid` — encodes ASID only for `aside1` / `aside1is`

Both types provide `new()` for structured construction and `from_raw()` for pre-encoded values.

### Instructions covered

| Category | Instructions |
|----------|-------------|
| No operand | `vmalle1`, `vmalle1is` |
| VA + ASID (`Addr`) | `vae1`, `vale1`, `vaae1`, `vaale1` + IS variants |
| ASID only (`Asid`) | `aside1`, `aside1is` |

## Motivation

The crate already wraps DSB/ISB barrier instructions but has no TLBI support, forcing downstream users to write inline assembly for TLB maintenance. For example, [SimpleKernel](https://github.com/Simple-XX/SimpleKernel) currently uses raw `asm!("tlbi vmalle1", "dsb sy", "isb")` in its memory management code because no wrapper is available.

## Design

- **Typed operands over raw `u64`**: Inspired by how `barrier.rs` uses type-level dispatch. `Addr` and `Asid` are `#[repr(transparent)]` newtypes — zero runtime cost, compile-time misuse prevention.
- **Two types, not three**: VA+ASID and VA-only share the same `Addr` type (pass `asid = 0` for all-ASID variants like `vaae1`). The ASID field is RES0/ignored by hardware for these instructions, so a separate type would add API surface without meaningful safety benefit.
- **Macro-generated wrappers**: `tlbi_no_arg!` / `tlbi_arg!` eliminate repetition across 12 instruction wrappers, following the `dmb_dsb!` pattern in `barrier.rs`.
- **Safe functions**: Consistent with existing wrappers (`nop`, `wfi`, `dsb`, etc.). The `unsafe` scope is limited to the `asm!` call.
- **VA mask (44-bit)**: Uses `0x0000_0FFF_FFFF_FFFF` matching bits [43:0] per Arm ARM, ensuring RES0 bits [47:44] are always zero. This is important for kernel (TTBR1) addresses where upper VA bits are all-ones.
- **Type names**: `Addr` and `Asid` instead of `TlbiAddr`/`TlbiAsid` — avoids redundancy with the `tlbi::` module path, following `barrier.rs` convention (e.g. `barrier::SY`, not `barrier::BarrierSY`). Types are not EL-specific, so they can be reused when EL2/EL3 instructions are added later.

### Future work (documented in module docs)

- FEAT_TTL (ARMv8.4): TTL hint in bits [47:44]
- FEAT_TLBIRANGE (ARMv8.4): Range-based TLBI (`RVAE1`, `RVALE1`, etc.)
- Outer Shareable variants (ARMv8.4): `VMALLE1OS`, `VAE1OS`, etc.

## Verification

All 12 instructions verified via cross-compilation + disassembly:

| Instruction | Opcode | Operand |
|---|---|---|
| `tlbi vmalle1` | `d508871f` | none (xzr) |
| `tlbi vmalle1is` | `d508831f` | none (xzr) |
| `tlbi vae1, x0` | `d5088720` | register |
| `tlbi vae1is, x0` | `d5088320` | register |
| `tlbi vale1, x0` | `d50887a0` | register |
| `tlbi vale1is, x0` | `d50883a0` | register |
| `tlbi vaae1, x0` | `d5088760` | register |
| `tlbi vaae1is, x0` | `d5088360` | register |
| `tlbi vaale1, x0` | `d50887e0` | register |
| `tlbi vaale1is, x0` | `d50883e0` | register |
| `tlbi aside1, x0` | `d5088740` | register |
| `tlbi aside1is, x0` | `d5088340` | register |

## Test plan

- [x] `cargo build --target aarch64-unknown-none-softfloat` — compiles
- [x] `cargo build` (host target) — compiles
- [x] `cargo fmt --check` — passes
- [x] `cargo clippy --target aarch64-unknown-none-softfloat` — no warnings
- [x] Cross-compiled test crate + `objdump` — all 12 opcodes match ARM ARM encoding