### PR TITLE
feat: Re-export FieldValue and TryFromValue

### DIFF
--- a/src/registers.rs
+++ b/src/registers.rs
@@ -298,4 +298,6 @@ pub use vtcr_el2::VTCR_EL2;
 pub use vttbr_el2::VTTBR_EL2;
 
 #[doc(inline)]
+pub use tock_registers::fields::{FieldValue, TryFromValue};
+#[doc(inline)]
 pub use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};


### PR DESCRIPTION
These two are exposed in the public API and it would be undesirable for consumers to depend on tock-registers directly, since that would need to be kept in lockstep with aarch64-cpu's dependency version. Therefore it makes sense to just re-export them.