### PR TITLE
Add missing TGran4 value

### DIFF
--- a/packages/aarch64-cpu/src/registers/id_aa64mmfr0_el1.rs
+++ b/packages/aarch64-cpu/src/registers/id_aa64mmfr0_el1.rs
@@ -17,11 +17,13 @@ register_bitfields! {u64,
         /// Support for 4KiB memory translation granule size. Defined values are:
         ///
         /// 0000 4KiB granule supported.
+        /// 0001 4KiB granule supports 52-bit input addresses and can describe 52-bit output addresses. (Applies when FEAT_LPA2 is implemented)
         /// 1111 4KiB granule not supported.
         ///
         /// All other values are reserved.
         TGran4  OFFSET(28) NUMBITS(4) [
             Supported = 0b0000,
+            SupportedWith52BitAddresses = 0b0001,
             NotSupported = 0b1111
         ],
 


### PR DESCRIPTION
An additional value is defined in [the Arm A-profile Architecture Registers documentation](https://developer.arm.com/documentation/ddi0601/2026-06/AArch64-Registers/ID-AA64MMFR0-EL1--AArch64-Memory-Model-Feature-Register-0#fieldset_0-31_28).